### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/composer-release.yml
+++ b/.github/workflows/composer-release.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }} # Use the default GITHUB_TOKEN
@@ -48,7 +48,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check-tag.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ env.VERSION }}
           name: Release v${{ env.VERSION }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -14,12 +14,12 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Need full history for release notes
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           draft: false
           generate_release_notes: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,29 @@ on:
 
 jobs:
   test:
+    name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.3', '8.4', '8.5']
+        laravel:
+          - name: '11'
+            version: '^11.0@stable'
+            testbench: '^9.0'
+            phpunit: '^10.5'
+            # Laravel 11 is security-EOL, so Composer blocks its stable releases.
+            composer_options: '--no-blocking'
+          - name: '12'
+            version: '^12.0@stable'
+            testbench: '^10.0'
+            phpunit: '^11.5'
+            composer_options: ''
+          - name: '13'
+            version: '^13.0@stable'
+            testbench: '^11.0'
+            phpunit: '^11.5'
+            composer_options: ''
     permissions:
       contents: read
       checks: write # For test results upload
@@ -22,7 +44,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
           coverage: xdebug
           ini-values: error_reporting=E_ALL
@@ -43,7 +65,15 @@ jobs:
             ${{ runner.os }}-php-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: >-
+          composer update
+          --with "orchestra/testbench:${{ matrix.laravel.testbench }}"
+          --with "laravel/framework:${{ matrix.laravel.version }}"
+          --with "phpunit/phpunit:${{ matrix.laravel.phpunit }}"
+          --prefer-dist
+          --no-interaction
+          --no-progress
+          ${{ matrix.laravel.composer_options }}
 
       - name: Execute tests
         run: vendor/bin/phpunit --coverage-clover=coverage.xml --log-junit junit.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2 # For coverage comparisons
 
@@ -57,7 +57,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -79,7 +79,7 @@ jobs:
         run: vendor/bin/phpunit --coverage-clover=coverage.xml --log-junit junit.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage.xml
           verbose: true     

--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,12 @@
     "license": "MIT",
     "require": {
         "php": "^8.3|^8.4",
-        "illuminate/support": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
         "guzzlehttp/guzzle": "^7.10"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0",
-        "orchestra/testbench": "^8.0|^9.0",
+        "phpunit/phpunit": "^10.5|^11.5",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "phpstan/phpstan": "^1.10",
         "friendsofphp/php-cs-fixer": "^3.92",
         "mockery/mockery": "^1.6",


### PR DESCRIPTION
## Summary

- allow `illuminate/support ^13.0` while retaining Laravel 11 and 12 support
- align the development stack with Testbench 9 / 10 / 11 for Laravel 11 / 12 / 13
- widen PHPUnit to the compatible 10.5 and 11.5 generations
- test every supported Laravel version on PHP 8.3, 8.4, and 8.5 in CI

## Compatibility matrix

| Laravel | Testbench | PHPUnit |
| --- | --- | --- |
| 11 | 9 | 10.5 |
| 12 | 10 | 11.5 |
| 13 | 11 | 11.5 |

Laravel 11 is security-EOL. Composer therefore blocks its stable releases by default; only that compatibility job uses `--no-blocking` so the package can continue verifying its declared Laravel 11 compatibility. Laravel 12 and 13 retain Composer's security blocking.

## Verification

Local verification on PHP 8.4:

- Laravel 11.55.0 / Testbench 9.17.0: 223 tests, 924 assertions
- Laravel 12.64.0 / Testbench 10.11.0: 223 tests, 924 assertions
- Laravel 13.20.0 / Testbench 11.1.0: 223 tests, 924 assertions
- `composer validate --strict`
- `composer audit` on Laravel 13: no known security advisories
- `vendor/bin/phpstan analyse src --memory-limit=512M`: no errors
- workflow YAML validation and `git diff --check`

Fixes #45.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added compatibility for Laravel 13 and its supporting development tools.
  - Expanded supported PHPUnit versions to include PHPUnit 11.

- **Tests**
  - Expanded automated testing across PHP 8.3–8.5 and Laravel 11–13.
  - Updated dependency testing to validate each supported framework and tool combination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->