### PR TITLE
test: remove confidential sandbox URLs

### DIFF
--- a/tests/Feature/FinancialTransactionResourceTest.php
+++ b/tests/Feature/FinancialTransactionResourceTest.php
@@ -160,7 +160,7 @@ class FinancialTransactionResourceTest extends TestCase
         $this->assertInstanceOf(UpdateResponse::class, $result);
         $this->assertEquals('016e0873-9a2b-41ca-a749-c1a3cc5945d8', $result->getId());
         $this->assertEquals(2, $result->getVersion());
-        $this->assertEquals('https://api.lexware-sandbox.io/v1/finance/accounts/016e0873-9a2b-41ca-a749-c1a3cc5945d8', $result->getResourceUri());
+        $this->assertEquals('https://api.sandbox.example.invalid/v1/finance/accounts/016e0873-9a2b-41ca-a749-c1a3cc5945d8', $result->getResourceUri());
         $this->assertEquals(Carbon::parse('2023-04-05T12:30:00.000+02:00'), $result->getCreatedDate());
         $this->assertEquals(Carbon::parse('2023-04-07T13:00:00.000+02:00'), $result->getUpdatedDate());
     }

--- a/tests/Feature/FinancialTransactionResourceTest.php
+++ b/tests/Feature/FinancialTransactionResourceTest.php
@@ -160,7 +160,7 @@ class FinancialTransactionResourceTest extends TestCase
         $this->assertInstanceOf(UpdateResponse::class, $result);
         $this->assertEquals('016e0873-9a2b-41ca-a749-c1a3cc5945d8', $result->getId());
         $this->assertEquals(2, $result->getVersion());
-        $this->assertEquals('https://api.sandbox.example.invalid/v1/finance/accounts/016e0873-9a2b-41ca-a749-c1a3cc5945d8', $result->getResourceUri());
+        $this->assertEquals('https://api.sandbox.example.com/v1/finance/accounts/016e0873-9a2b-41ca-a749-c1a3cc5945d8', $result->getResourceUri());
         $this->assertEquals(Carbon::parse('2023-04-05T12:30:00.000+02:00'), $result->getCreatedDate());
         $this->assertEquals(Carbon::parse('2023-04-07T13:00:00.000+02:00'), $result->getUpdatedDate());
     }

--- a/tests/Fixtures/contacts/api_responses/company_contact_create_response.json
+++ b/tests/Fixtures/contacts/api_responses/company_contact_create_response.json
@@ -1,6 +1,6 @@
 {
     "id": "87654321-abcd-1234-efgh-987654321987",
-    "resourceUri": "https://api-sandbox.grld.eu/v1/contacts/87654321-abcd-1234-efgh-987654321987",
+    "resourceUri": "https://api.sandbox.example.invalid/v1/contacts/87654321-abcd-1234-efgh-987654321987",
     "createdDate": "2023-06-29T15:15:09.447+02:00",
     "updatedDate": "2023-06-29T15:15:09.447+02:00",
     "version": 1

--- a/tests/Fixtures/contacts/api_responses/company_contact_create_response.json
+++ b/tests/Fixtures/contacts/api_responses/company_contact_create_response.json
@@ -1,6 +1,6 @@
 {
     "id": "87654321-abcd-1234-efgh-987654321987",
-    "resourceUri": "https://api.sandbox.example.invalid/v1/contacts/87654321-abcd-1234-efgh-987654321987",
+    "resourceUri": "https://api.sandbox.example.com/v1/contacts/87654321-abcd-1234-efgh-987654321987",
     "createdDate": "2023-06-29T15:15:09.447+02:00",
     "updatedDate": "2023-06-29T15:15:09.447+02:00",
     "version": 1

--- a/tests/Fixtures/contacts/api_responses/complete_person_contact_create_response.json
+++ b/tests/Fixtures/contacts/api_responses/complete_person_contact_create_response.json
@@ -1,6 +1,6 @@
 {
     "id": "66196c43-baf3-4335-bfee-d610367059db",
-    "resourceUri": "https://api-sandbox.grld.eu/v1/contacts/66196c43-baf3-4335-bfee-d610367059db",
+    "resourceUri": "https://api.sandbox.example.invalid/v1/contacts/66196c43-baf3-4335-bfee-d610367059db",
     "createdDate": "2023-06-29T15:15:09.447+02:00",
     "updatedDate": "2023-06-29T15:15:09.447+02:00",
     "version": 1

--- a/tests/Fixtures/contacts/api_responses/complete_person_contact_create_response.json
+++ b/tests/Fixtures/contacts/api_responses/complete_person_contact_create_response.json
@@ -1,6 +1,6 @@
 {
     "id": "66196c43-baf3-4335-bfee-d610367059db",
-    "resourceUri": "https://api.sandbox.example.invalid/v1/contacts/66196c43-baf3-4335-bfee-d610367059db",
+    "resourceUri": "https://api.sandbox.example.com/v1/contacts/66196c43-baf3-4335-bfee-d610367059db",
     "createdDate": "2023-06-29T15:15:09.447+02:00",
     "updatedDate": "2023-06-29T15:15:09.447+02:00",
     "version": 1

--- a/tests/Fixtures/contacts/api_responses/multiple_address_types_create_response.json
+++ b/tests/Fixtures/contacts/api_responses/multiple_address_types_create_response.json
@@ -1,6 +1,6 @@
 {
     "id": "44444444-bbbb-4444-cccc-444444444444",
-    "resourceUri": "https://api.sandbox.example.invalid/v1/contacts/44444444-bbbb-4444-cccc-444444444444",
+    "resourceUri": "https://api.sandbox.example.com/v1/contacts/44444444-bbbb-4444-cccc-444444444444",
     "createdDate": "2023-06-29T15:15:09.447+02:00",
     "updatedDate": "2023-06-29T15:15:09.447+02:00",
     "version": 1

--- a/tests/Fixtures/contacts/api_responses/multiple_address_types_create_response.json
+++ b/tests/Fixtures/contacts/api_responses/multiple_address_types_create_response.json
@@ -1,6 +1,6 @@
 {
     "id": "44444444-bbbb-4444-cccc-444444444444",
-    "resourceUri": "https://api-sandbox.grld.eu/v1/contacts/44444444-bbbb-4444-cccc-444444444444",
+    "resourceUri": "https://api.sandbox.example.invalid/v1/contacts/44444444-bbbb-4444-cccc-444444444444",
     "createdDate": "2023-06-29T15:15:09.447+02:00",
     "updatedDate": "2023-06-29T15:15:09.447+02:00",
     "version": 1

--- a/tests/Fixtures/contacts/api_responses/multiple_email_phone_create_response.json
+++ b/tests/Fixtures/contacts/api_responses/multiple_email_phone_create_response.json
@@ -1,6 +1,6 @@
 {
     "id": "12345678-abcd-1234-efgh-123456789012",
-    "resourceUri": "https://api-sandbox.grld.eu/v1/contacts/12345678-abcd-1234-efgh-123456789012",
+    "resourceUri": "https://api.sandbox.example.invalid/v1/contacts/12345678-abcd-1234-efgh-123456789012",
     "createdDate": "2023-06-29T15:15:09.447+02:00",
     "updatedDate": "2023-06-29T15:15:09.447+02:00",
     "version": 1

--- a/tests/Fixtures/contacts/api_responses/multiple_email_phone_create_response.json
+++ b/tests/Fixtures/contacts/api_responses/multiple_email_phone_create_response.json
@@ -1,6 +1,6 @@
 {
     "id": "12345678-abcd-1234-efgh-123456789012",
-    "resourceUri": "https://api.sandbox.example.invalid/v1/contacts/12345678-abcd-1234-efgh-123456789012",
+    "resourceUri": "https://api.sandbox.example.com/v1/contacts/12345678-abcd-1234-efgh-123456789012",
     "createdDate": "2023-06-29T15:15:09.447+02:00",
     "updatedDate": "2023-06-29T15:15:09.447+02:00",
     "version": 1

--- a/tests/Fixtures/financial-transactions/2_financial_transaction_update_response.json
+++ b/tests/Fixtures/financial-transactions/2_financial_transaction_update_response.json
@@ -1,6 +1,6 @@
 {
   "id": "016e0873-9a2b-41ca-a749-c1a3cc5945d8",
-  "resourceUri": "https://api.sandbox.example.invalid/v1/finance/accounts/016e0873-9a2b-41ca-a749-c1a3cc5945d8",
+  "resourceUri": "https://api.sandbox.example.com/v1/finance/accounts/016e0873-9a2b-41ca-a749-c1a3cc5945d8",
   "createdDate": "2023-04-05T12:30:00.000+02:00",
   "updatedDate": "2023-04-07T13:00:00.000+02:00",
   "version": 2

--- a/tests/Fixtures/financial-transactions/2_financial_transaction_update_response.json
+++ b/tests/Fixtures/financial-transactions/2_financial_transaction_update_response.json
@@ -1,6 +1,6 @@
 {
   "id": "016e0873-9a2b-41ca-a749-c1a3cc5945d8",
-  "resourceUri": "https://api.lexware-sandbox.io/v1/finance/accounts/016e0873-9a2b-41ca-a749-c1a3cc5945d8",
+  "resourceUri": "https://api.sandbox.example.invalid/v1/finance/accounts/016e0873-9a2b-41ca-a749-c1a3cc5945d8",
   "createdDate": "2023-04-05T12:30:00.000+02:00",
   "updatedDate": "2023-04-07T13:00:00.000+02:00",
   "version": 2

--- a/tests/Fixtures/financial-transactions/update_response.json
+++ b/tests/Fixtures/financial-transactions/update_response.json
@@ -1,6 +1,6 @@
 {
   "id": "016e0873-9a2b-41ca-a749-c1a3cc5945d8",
-  "resourceUri": "https://api.sandbox.example.invalid/v1/finance/accounts/016e0873-9a2b-41ca-a749-c1a3cc5945d8",
+  "resourceUri": "https://api.sandbox.example.com/v1/finance/accounts/016e0873-9a2b-41ca-a749-c1a3cc5945d8",
   "createdDate": "2023-04-05T12:30:00.000+02:00",
   "updatedDate": "2023-04-07T13:00:00.000+02:00",
   "version": 2

--- a/tests/Fixtures/financial-transactions/update_response.json
+++ b/tests/Fixtures/financial-transactions/update_response.json
@@ -1,6 +1,6 @@
 {
   "id": "016e0873-9a2b-41ca-a749-c1a3cc5945d8",
-  "resourceUri": "https://api.lexware-sandbox.io/v1/finance/accounts/016e0873-9a2b-41ca-a749-c1a3cc5945d8",
+  "resourceUri": "https://api.sandbox.example.invalid/v1/finance/accounts/016e0873-9a2b-41ca-a749-c1a3cc5945d8",
   "createdDate": "2023-04-05T12:30:00.000+02:00",
   "updatedDate": "2023-04-07T13:00:00.000+02:00",
   "version": 2


### PR DESCRIPTION
## Summary
- replace confidential sandbox resource URIs in test fixtures
- update the matching feature assertion to the neutral placeholder host
- keep coverage of resource URI parsing without publishing real internal endpoints

## Testing
- verified the repo no longer contains the previously published confidential sandbox URLs