### PR TITLE
Add voucher create with file upload workflow

### DIFF
--- a/src/Exceptions/VoucherFileAttachmentFailedException.php
+++ b/src/Exceptions/VoucherFileAttachmentFailedException.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Pirabyte\LaravelLexwareOffice\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Raised when a voucher was created but the immediate file upload failed.
+ */
+final class VoucherFileAttachmentFailedException extends RuntimeException
+{
+    /**
+     * @param  array<string, mixed>  $voucher  Metadata for the already-created voucher.
+     * @param  \Throwable  $previous  Original upload failure.
+     */
+    public function __construct(
+        private readonly array $voucher,
+        \Throwable $previous,
+    ) {
+        parent::__construct(
+            'Voucher was created, but attaching the file failed.',
+            0,
+            $previous,
+        );
+    }
+
+    /**
+     * Get the voucher that was created before the file upload failed.
+     *
+     * @return array<string, mixed>
+     */
+    public function getVoucher(): array
+    {
+        return $this->voucher;
+    }
+}

--- a/src/LexwareOffice.php
+++ b/src/LexwareOffice.php
@@ -348,6 +348,50 @@ class LexwareOffice
     }
 
     /**
+     * Wait until the local Laravel rate limiter has enough capacity.
+     *
+     * This only coordinates the package's local limiter. It does not reserve
+     * capacity and does not guarantee that Lexware's remote token bucket will
+     * accept the following request.
+     *
+     * @param  int  $requiredAttempts  Number of upcoming HTTP attempts to wait for.
+     * @param  int|null  $maxWaitSeconds  Maximum seconds to wait before throwing a local rate-limit exception.
+     * @param  int|null  $maxAttempts  Maximum limiter checks to perform before throwing a local rate-limit exception.
+     *
+     * @throws LexwareOfficeApiException
+     */
+    public function waitForRateLimitCapacity(int $requiredAttempts, ?int $maxWaitSeconds = 120, ?int $maxAttempts = null): void
+    {
+        if ($this->maxRequestsPerMinute <= 0 || $requiredAttempts <= 0) {
+            return;
+        }
+
+        $requiredAttempts = min($requiredAttempts, $this->maxRequestsPerMinute);
+        $startedAt = microtime(true);
+        $attempts = 0;
+
+        while (true) {
+            $attempts++;
+
+            if (RateLimiter::tooManyAttempts($this->rateLimitKey, $this->maxRequestsPerMinute)) {
+                $this->throwIfRateLimitWaitExceeded($startedAt, $attempts, $maxWaitSeconds, $maxAttempts);
+                $this->sleepUntilRateLimitAvailable($startedAt, $maxWaitSeconds);
+                $this->throwIfRateLimitWaitExceeded($startedAt, $attempts, $maxWaitSeconds, $maxAttempts);
+
+                continue;
+            }
+
+            if (RateLimiter::remaining($this->rateLimitKey, $this->maxRequestsPerMinute) >= $requiredAttempts) {
+                return;
+            }
+
+            $this->throwIfRateLimitWaitExceeded($startedAt, $attempts, $maxWaitSeconds, $maxAttempts);
+            $this->sleepUntilRateLimitAvailable($startedAt, $maxWaitSeconds);
+            $this->throwIfRateLimitWaitExceeded($startedAt, $attempts, $maxWaitSeconds, $maxAttempts);
+        }
+    }
+
+    /**
      * PUT-Anfrage
      *
      * @throws LexwareOfficeApiException|GuzzleException
@@ -483,6 +527,10 @@ class LexwareOffice
      */
     protected function makeRequest(callable $callback)
     {
+        if ($this->maxRequestsPerMinute <= 0) {
+            return $this->executeRequest($callback);
+        }
+
         // Check if we've exceeded our self-imposed rate limit
         if (RateLimiter::tooManyAttempts($this->rateLimitKey, $this->maxRequestsPerMinute)) {
             $seconds = RateLimiter::availableIn($this->rateLimitKey);
@@ -500,6 +548,18 @@ class LexwareOffice
             );
         }
 
+        return $this->executeRequest($callback);
+    }
+
+    /**
+     * Execute the HTTP callback and decode its response.
+     *
+     * @return array<string, mixed>
+     *
+     * @throws LexwareOfficeApiException
+     */
+    protected function executeRequest(callable $callback): array
+    {
         // Ensure valid OAuth2 token if OAuth2 is configured
         $this->ensureValidToken();
 
@@ -508,7 +568,9 @@ class LexwareOffice
             $response = $callback();
 
             // Track the request for our rate limiter
-            RateLimiter::hit($this->rateLimitKey, 60);
+            if ($this->maxRequestsPerMinute > 0) {
+                RateLimiter::hit($this->rateLimitKey, 60);
+            }
 
             // Parse and return the response data
             $content = $response->getBody()->getContents();
@@ -527,7 +589,9 @@ class LexwareOffice
                 if ($this->refreshTokenAndRetry()) {
                     try {
                         $response = $callback();
-                        RateLimiter::hit($this->rateLimitKey, 60);
+                        if ($this->maxRequestsPerMinute > 0) {
+                            RateLimiter::hit($this->rateLimitKey, 60);
+                        }
 
                         $content = $response->getBody()->getContents();
                         $data = json_decode($content, true);
@@ -547,6 +611,56 @@ class LexwareOffice
             // Handle request exceptions (HTTP errors, etc.)
             throw $this->handleRequestException($e);
         }
+    }
+
+    /**
+     * Sleep until the local rate limiter is expected to have capacity.
+     *
+     * @throws LexwareOfficeApiException
+     */
+    protected function sleepUntilRateLimitAvailable(float $startedAt, ?int $maxWaitSeconds): void
+    {
+        $seconds = (float) max(1, RateLimiter::availableIn($this->rateLimitKey));
+
+        if ($maxWaitSeconds !== null) {
+            $remainingSeconds = $maxWaitSeconds - (microtime(true) - $startedAt);
+            if ($remainingSeconds <= 0) {
+                throw $this->localRateLimitWaitExceededException();
+            }
+
+            $seconds = min($seconds, $remainingSeconds);
+        }
+
+        usleep((int) ceil($seconds * 1_000_000));
+    }
+
+    /**
+     * @throws LexwareOfficeApiException
+     */
+    protected function throwIfRateLimitWaitExceeded(
+        float $startedAt,
+        int $attempts,
+        ?int $maxWaitSeconds,
+        ?int $maxAttempts,
+    ): void {
+        if ($maxAttempts !== null && $attempts >= $maxAttempts) {
+            throw $this->localRateLimitWaitExceededException();
+        }
+
+        if ($maxWaitSeconds !== null && microtime(true) - $startedAt >= $maxWaitSeconds) {
+            throw $this->localRateLimitWaitExceededException();
+        }
+    }
+
+    protected function localRateLimitWaitExceededException(): LexwareOfficeApiException
+    {
+        $seconds = RateLimiter::availableIn($this->rateLimitKey);
+
+        return new LexwareOfficeApiException(json_encode([
+            'message' => 'Rate limit wait exceeded',
+            'details' => 'Timed out while waiting for local rate limit capacity.',
+            'retryAfter' => $seconds,
+        ]), LexwareOfficeApiException::STATUS_RATE_LIMITED);
     }
 
     /**

--- a/src/Models/VoucherCreateWithFileResult.php
+++ b/src/Models/VoucherCreateWithFileResult.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Pirabyte\LaravelLexwareOffice\Models;
+
+/**
+ * Result of creating a voucher and attaching a file in one package-level workflow.
+ */
+final class VoucherCreateWithFileResult
+{
+    /**
+     * @param  array<string, mixed>  $voucher  Metadata returned by Lexware for the created voucher.
+     * @param  array<string, mixed>  $file  Metadata returned by Lexware for the uploaded file.
+     */
+    public function __construct(
+        public readonly array $voucher,
+        public readonly array $file,
+    ) {}
+}

--- a/src/Resources/VoucherResource.php
+++ b/src/Resources/VoucherResource.php
@@ -5,8 +5,10 @@ namespace Pirabyte\LaravelLexwareOffice\Resources;
 use GuzzleHttp\Exception\GuzzleException;
 use Pirabyte\LaravelLexwareOffice\Exceptions\LexwareOfficeApiException;
 use Pirabyte\LaravelLexwareOffice\Exceptions\OptimisticLockingException;
+use Pirabyte\LaravelLexwareOffice\Exceptions\VoucherFileAttachmentFailedException;
 use Pirabyte\LaravelLexwareOffice\LexwareOffice;
 use Pirabyte\LaravelLexwareOffice\Models\Voucher;
+use Pirabyte\LaravelLexwareOffice\Models\VoucherCreateWithFileResult;
 use Psr\Http\Message\StreamInterface;
 
 class VoucherResource
@@ -27,7 +29,7 @@ class VoucherResource
     public function create(Voucher $voucher): Voucher
     {
         $data = $voucher->jsonSerialize();
-        $response = $this->client->post('vouchers', $data);
+        $response = $this->createVoucherResponse($voucher);
 
         // Holen des kompletten Belegs wenn ID vorhanden
         if (isset($response['id'])) {
@@ -39,6 +41,75 @@ class VoucherResource
         }
 
         return Voucher::fromArray(array_merge($data, $response));
+    }
+
+    /**
+     * Create a voucher and immediately attach a file to it.
+     *
+     * This method intentionally uses the create response metadata directly instead
+     * of calling create(), because create() may perform an additional GET request.
+     * The operation is not transactional in Lexware Office: if the upload fails
+     * after voucher creation, a VoucherFileAttachmentFailedException is thrown
+     * and contains the created voucher metadata for recovery or retry.
+     *
+     * @param  Voucher  $voucher  Voucher payload to create.
+     * @param  StreamInterface  $stream  File contents to upload.
+     * @param  string  $filename  Uploaded file name sent in the multipart request.
+     * @param  string  $type  Lexware file type, defaults to voucher.
+     * @return VoucherCreateWithFileResult Created voucher metadata and uploaded file metadata.
+     *
+     * @throws VoucherFileAttachmentFailedException When voucher creation succeeded but file upload failed.
+     * @throws LexwareOfficeApiException When Lexware rejects voucher creation or rate limiting fails.
+     * @throws GuzzleException When the HTTP transport fails.
+     */
+    public function createAndAttachFile(
+        Voucher $voucher,
+        StreamInterface $stream,
+        string $filename = 'voucher.pdf',
+        string $type = 'voucher',
+    ): VoucherCreateWithFileResult {
+        $this->client->waitForRateLimitCapacity(2);
+
+        $createdVoucher = $this->createVoucherResponse($voucher);
+        $voucherId = $this->extractCreatedVoucherId($createdVoucher);
+
+        $this->client->waitForRateLimitCapacity(1);
+
+        try {
+            $file = $this->attachFile($voucherId, $stream, $filename, $type);
+        } catch (\Throwable $e) {
+            throw new VoucherFileAttachmentFailedException($createdVoucher, $e);
+        }
+
+        return new VoucherCreateWithFileResult($createdVoucher, $file);
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws LexwareOfficeApiException|GuzzleException
+     */
+    protected function createVoucherResponse(Voucher $voucher): array
+    {
+        return $this->client->post('vouchers', $voucher->jsonSerialize());
+    }
+
+    /**
+     * @param  array<string, mixed>  $createdVoucher
+     *
+     * @throws LexwareOfficeApiException
+     */
+    protected function extractCreatedVoucherId(array $createdVoucher): string
+    {
+        $id = $createdVoucher['id'] ?? $createdVoucher['voucherId'] ?? null;
+
+        if (is_string($id) && $id !== '') {
+            return $id;
+        }
+
+        throw new LexwareOfficeApiException(json_encode([
+            'message' => 'Voucher creation response did not include an id',
+        ]), LexwareOfficeApiException::STATUS_SERVER_ERROR);
     }
 
     /**

--- a/tests/Feature/VoucherFileUploadTest.php
+++ b/tests/Feature/VoucherFileUploadTest.php
@@ -6,11 +6,17 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
+use Illuminate\Support\Facades\RateLimiter;
+use Mockery;
 use Pirabyte\LaravelLexwareOffice\Exceptions\LexwareOfficeApiException;
+use Pirabyte\LaravelLexwareOffice\Exceptions\VoucherFileAttachmentFailedException;
 use Pirabyte\LaravelLexwareOffice\LexwareOffice;
+use Pirabyte\LaravelLexwareOffice\Models\Voucher;
+use Pirabyte\LaravelLexwareOffice\Models\VoucherCreateWithFileResult;
 use Pirabyte\LaravelLexwareOffice\Tests\TestCase;
 
 class VoucherFileUploadTest extends TestCase
@@ -290,18 +296,192 @@ class VoucherFileUploadTest extends TestCase
         // and the request went through the proper client methods
     }
 
+    public function test_it_can_create_voucher_and_attach_file_in_one_call()
+    {
+        $history = [];
+        $mock = new MockHandler([
+            new Response(201, ['Content-Type' => 'application/json'], json_encode($this->voucherCreateResponse())),
+            new Response(201, ['Content-Type' => 'application/json'], json_encode([
+                'id' => 'file_123',
+                'fileName' => 'invoice.pdf',
+                'mimeType' => 'application/pdf',
+            ])),
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $handlerStack->push(Middleware::history($history));
+        $client = new Client(['handler' => $handlerStack]);
+
+        $this->lexware->setRateLimitKey('voucher_create_attach_'.uniqid());
+        $this->setHttpClient($client);
+
+        $result = $this->lexware->vouchers()->createAndAttachFile(
+            $this->makeVoucher(),
+            Utils::streamFor('%PDF-1.4 test content'),
+            'invoice.pdf',
+            'voucher',
+        );
+
+        $this->assertInstanceOf(VoucherCreateWithFileResult::class, $result);
+        $this->assertEquals('voucher_123', $result->voucher['id']);
+        $this->assertEquals('file_123', $result->file['id']);
+        $this->assertEquals('invoice.pdf', $result->file['fileName']);
+
+        $this->assertCount(2, $history);
+        $this->assertEquals('POST', $history[0]['request']->getMethod());
+        $this->assertEquals('vouchers', (string) $history[0]['request']->getUri());
+        $this->assertEquals('POST', $history[1]['request']->getMethod());
+        $this->assertEquals('vouchers/voucher_123/files', (string) $history[1]['request']->getUri());
+    }
+
+    public function test_create_and_attach_file_wraps_upload_failure_with_created_voucher_context()
+    {
+        $request = new Request('POST', 'vouchers/voucher_123/files');
+        $mock = new MockHandler([
+            new Response(201, ['Content-Type' => 'application/json'], json_encode($this->voucherCreateResponse())),
+            new RequestException(
+                'Rate limit exceeded',
+                $request,
+                new Response(429, ['Retry-After' => '30'], '{"message":"Rate limit exceeded"}'),
+            ),
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $this->lexware->setRateLimitKey('voucher_create_attach_failure_'.uniqid());
+        $this->setHttpClient($client);
+
+        try {
+            $this->lexware->vouchers()->createAndAttachFile(
+                $this->makeVoucher(),
+                Utils::streamFor('%PDF-1.4 test content'),
+            );
+
+            $this->fail('Expected voucher attachment failure exception.');
+        } catch (VoucherFileAttachmentFailedException $e) {
+            $this->assertEquals('voucher_123', $e->getVoucher()['id']);
+            $this->assertInstanceOf(LexwareOfficeApiException::class, $e->getPrevious());
+        }
+    }
+
+    public function test_wait_for_rate_limit_capacity_throws_when_attempt_limit_is_exceeded()
+    {
+        RateLimiter::shouldReceive('tooManyAttempts')
+            ->once()
+            ->with('wait_timeout_key', 5)
+            ->andReturn(false);
+        RateLimiter::shouldReceive('remaining')
+            ->once()
+            ->with('wait_timeout_key', 5)
+            ->andReturn(0);
+        RateLimiter::shouldReceive('availableIn')
+            ->once()
+            ->with('wait_timeout_key')
+            ->andReturn(12);
+
+        $this->lexware->setRateLimitKey('wait_timeout_key');
+        $this->lexware->setRateLimit(5);
+
+        $this->expectException(LexwareOfficeApiException::class);
+        $this->expectExceptionCode(429);
+
+        $this->lexware->waitForRateLimitCapacity(2, maxAttempts: 1);
+    }
+
+    public function test_zero_rate_limit_disables_local_limiter_for_create_and_attach_file()
+    {
+        RateLimiter::shouldReceive('tooManyAttempts')->never();
+        RateLimiter::shouldReceive('remaining')->never();
+        RateLimiter::shouldReceive('availableIn')->never();
+        RateLimiter::shouldReceive('hit')->never();
+
+        $mock = new MockHandler([
+            new Response(201, ['Content-Type' => 'application/json'], json_encode($this->voucherCreateResponse())),
+            new Response(201, ['Content-Type' => 'application/json'], json_encode([
+                'id' => 'file_without_limit',
+                'fileName' => 'voucher.pdf',
+                'mimeType' => 'application/pdf',
+            ])),
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $lexware = new LexwareOffice(
+            'https://api.lexoffice.de',
+            'test_api_key',
+            'disabled_limit_'.uniqid(),
+            0,
+        );
+        $this->setHttpClient($client, $lexware);
+
+        $result = $lexware->vouchers()->createAndAttachFile(
+            $this->makeVoucher(),
+            Utils::streamFor('%PDF-1.4 test content'),
+        );
+
+        $this->assertEquals('voucher_123', $result->voucher['id']);
+        $this->assertEquals('file_without_limit', $result->file['id']);
+    }
+
     private function setMockHttpClient(MockHandler $mock): void
     {
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(['handler' => $handlerStack]);
 
+        $this->setHttpClient($client);
+    }
+
+    private function setHttpClient(Client $client, ?LexwareOffice $lexware = null): void
+    {
+        $lexware ??= $this->lexware;
+
         // Set both client properties to ensure compatibility
-        $reflection = new \ReflectionClass($this->lexware);
+        $reflection = new \ReflectionClass($lexware);
 
         $clientProperty = $reflection->getProperty('client');
-        $clientProperty->setValue($this->lexware, $client);
+        $clientProperty->setValue($lexware, $client);
 
         $httpClientProperty = $reflection->getProperty('httpClient');
-        $httpClientProperty->setValue($this->lexware, $client);
+        $httpClientProperty->setValue($lexware, $client);
+    }
+
+    private function makeVoucher(): Voucher
+    {
+        return Voucher::fromArray([
+            'type' => 'salesinvoice',
+            'voucherDate' => '2023-06-28T00:00:00.000+02:00',
+            'totalGrossAmount' => 119.0,
+            'totalTaxAmount' => 19.0,
+            'taxType' => 'gross',
+            'useCollectiveContact' => true,
+            'voucherItems' => [
+                [
+                    'amount' => 119.0,
+                    'taxAmount' => 19.0,
+                    'taxRatePercent' => 19.0,
+                    'categoryId' => '8f8664a8-fd86-11e1-a21f-0800200c9a66',
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function voucherCreateResponse(): array
+    {
+        return [
+            'id' => 'voucher_123',
+            'resourceUri' => 'https://api.lexoffice.de/v1/vouchers/voucher_123',
+            'createdDate' => '2023-06-29T15:15:09.447+02:00',
+            'updatedDate' => '2023-06-29T15:15:09.447+02:00',
+            'version' => 1,
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
     }
 }


### PR DESCRIPTION
## Summary
- add a main-branch compatible createAndAttachFile workflow for vouchers
- wait for local rate-limit capacity before the create/upload sequence
- preserve created voucher metadata when the upload fails

## Tests
- vendor/bin/phpunit tests/Feature/VoucherFileUploadTest.php
- vendor/bin/phpunit
- vendor/bin/phpstan analyse src --no-progress
- coderabbit review --agent --base main (findings: 0)

This PR is intentionally based on main and does not include the v2 DTO refactor.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pirabyte/codesmith/laravel-lexware-office/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782736522&installation_id=129741645&pr_number=51&repository=pirabyte%2Flaravel-lexware-office&return_to=https%3A%2F%2Fgithub.com%2Fpirabyte%2Flaravel-lexware-office%2Fpull%2F51&signature=5ef80e177aaf128fc2feaee8d1e406145d25da242ee62e01df74ae44449bd35c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->