### PR TITLE
Fix financial account accountSystem decoding

### DIFF
--- a/src/Enums/AccountSystem.php
+++ b/src/Enums/AccountSystem.php
@@ -8,4 +8,6 @@ enum AccountSystem: string
     // Laut Dokumentation: "Please contact us to get a value for usage."
     case UNKNOWN = 'UNKNOWN';
     case PAYMENT_PROVIDER = 'PaymentProvider';
+    case HOLVI = 'Holvi';
+    case INTERNAL = 'Internal';
 }

--- a/src/Models/FinancialAccount.php
+++ b/src/Models/FinancialAccount.php
@@ -85,7 +85,7 @@ class FinancialAccount implements \JsonSerializable
             : $data['type'];
 
         $accountSystem = is_string($data['accountSystem'])
-            ? AccountSystem::from($data['accountSystem'])
+            ? AccountSystem::tryFrom($data['accountSystem']) ?? AccountSystem::UNKNOWN
             : $data['accountSystem'];
 
         // Objekt erstellen

--- a/tests/Feature/FinancialAccountResourceTest.php
+++ b/tests/Feature/FinancialAccountResourceTest.php
@@ -59,6 +59,42 @@ class FinancialAccountResourceTest extends TestCase
     }
 
     /** @test */
+    public function it_can_parse_holvi_account_system(): void
+    {
+        $fixtureData = json_decode(file_get_contents(__DIR__.'/../Fixtures/finance-accounts/1_create_financial_account_response.json'), true);
+        $fixtureData['type'] = 'GIRO';
+        $fixtureData['accountSystem'] = 'Holvi';
+        $fixtureData['bankName'] = 'Holvi';
+
+        $financialAccount = FinancialAccount::fromArray($fixtureData);
+
+        $this->assertEquals(AccountSystem::HOLVI, $financialAccount->getAccountSystem());
+        $this->assertEquals('Holvi', $financialAccount->getBankName());
+    }
+
+    /** @test */
+    public function it_can_parse_internal_account_system(): void
+    {
+        $fixtureData = json_decode(file_get_contents(__DIR__.'/../Fixtures/finance-accounts/1_create_financial_account_response.json'), true);
+        $fixtureData['accountSystem'] = 'Internal';
+
+        $financialAccount = FinancialAccount::fromArray($fixtureData);
+
+        $this->assertEquals(AccountSystem::INTERNAL, $financialAccount->getAccountSystem());
+    }
+
+    /** @test */
+    public function it_maps_unknown_account_systems_to_unknown(): void
+    {
+        $fixtureData = json_decode(file_get_contents(__DIR__.'/../Fixtures/finance-accounts/1_create_financial_account_response.json'), true);
+        $fixtureData['accountSystem'] = 'SomeFutureProvider';
+
+        $financialAccount = FinancialAccount::fromArray($fixtureData);
+
+        $this->assertEquals(AccountSystem::UNKNOWN, $financialAccount->getAccountSystem());
+    }
+
+    /** @test */
     public function it_can_parse_financial_accounts_from_filter_request(): void
     {
         $fixtureData = json_decode(file_get_contents(__DIR__.'/../Fixtures/finance-accounts/2_get_financial_account_response.json'), true);


### PR DESCRIPTION
## Summary
- add known AccountSystem enum values for Holvi and Internal
- map unknown accountSystem API values to UNKNOWN instead of throwing
- cover known and future accountSystem values in financial account tests

## Tests
- vendor/bin/phpunit tests/Feature/FinancialAccountResourceTest.php
- vendor/bin/phpstan analyse src --no-progress

CodeRabbit local review was skipped for this branch per instruction because the free CLI limit was active; GitHub/CodeRabbit will run on the PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pirabyte/codesmith/laravel-lexware-office/pr/52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782737265&installation_id=129741645&pr_number=52&repository=pirabyte%2Flaravel-lexware-office&return_to=https%3A%2F%2Fgithub.com%2Fpirabyte%2Flaravel-lexware-office%2Fpull%2F52&signature=f2fb4a5f170ecf39220ed5d089f46b81187c73b2a39e6bf00624be13043d6c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->