### PR TITLE
Document 404 behavior for empty financial accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,5 +108,18 @@ Wenn das Rate-Limit erreicht wird, wird eine `LexwareOfficeApiException` mit dem
 - Neueste Transaktionen abrufen
 - Belegzuweisungen abrufen
 
+#### Bekannte API-Eigenheit bei umsatzlosen Finanzkonten
+
+Der Endpunkt `finance/transactions/latest-transaction` kann mit HTTP 404 antworten,
+obwohl das angefragte Finanzkonto weiterhin in Lexware existiert. Dieses Verhalten
+wurde bei einem Finanzkonto ohne Transaktionen beobachtet. Ein 404 dieses Endpunkts
+darf daher nicht als alleiniger Nachweis verwendet werden, dass das Finanzkonto
+gelöscht wurde.
+
+`financialTransactions()->latest()` reicht diese 404-Antwort derzeit als
+`LexwareOfficeApiException` weiter. Nur eine erfolgreiche, aber leere Antwort wird
+als `null` zurückgegeben. Wenn die Existenz des Kontos relevant ist, muss sie separat
+über `financialAccounts()->get($financialAccountId)` geprüft werden.
+
 ### Transaktionszuweisungshinweise
 - Transaktionszuweisungshinweis erstellen

--- a/src/Resources/FinancialTransactionResource.php
+++ b/src/Resources/FinancialTransactionResource.php
@@ -123,10 +123,15 @@ class FinancialTransactionResource
     /**
      * Ruft die neueste Finanztransaktion für ein Konto ab
      *
-     * @param  string  $financialAccountId  Die ID des Finanzkontos
-     * @return FinancialTransaction|null Die neueste Transaktion oder null wenn keine vorhanden
+     * Achtung: Lexware kann für ein existierendes Finanzkonto ohne Transaktionen
+     * HTTP 404 zurückgeben. Dieser Status belegt deshalb nicht, dass das
+     * Finanzkonto selbst nicht mehr existiert. Das Konto muss bei Bedarf separat
+     * über FinancialAccountResource::get() geprüft werden.
      *
-     * @throws LexwareOfficeApiException
+     * @param  string  $financialAccountId  Die ID des Finanzkontos
+     * @return FinancialTransaction|null Die neueste Transaktion oder null bei einer erfolgreichen leeren Antwort
+     *
+     * @throws LexwareOfficeApiException Unter anderem bei der beschriebenen 404-Antwort
      */
     public function latest(string $financialAccountId): ?FinancialTransaction
     {


### PR DESCRIPTION
## Description

- documents that `latest-transaction` can return HTTP 404 for an existing financial account without transactions
- clarifies that `latest()` currently propagates that response as `LexwareOfficeApiException`
- warns consumers to verify the financial account separately before treating it as deleted

## Type of change

- [x] This change requires a documentation update

## How has this been tested?

- [x] `vendor/bin/phpunit tests/Feature/FinancialTransactionResourceTest.php`
- [x] `git diff --check`

## Checklist

- [x] I have performed a self-review
- [x] I have made corresponding changes to the documentation
- [x] Existing targeted tests pass locally

Documentation-only change; no executable behavior was modified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pirabyte/codesmith/laravel-lexware-office/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788878534&installation_model_id=20685&pr_number=54&repository=pirabyte%2Flaravel-lexware-office&return_to=https%3A%2F%2Fgithub.com%2Fpirabyte%2Flaravel-lexware-office%2Fpull%2F54&signature=eb84e22c953e5c285d282c586c18e7b0162ccca6fc24a7c48c2becbe9c7a1f11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that requesting the latest transaction may return a 404 when an existing financial account has no transactions.
  * Documented that 404 responses raise an API exception, while successful empty responses return `null`.
  * Noted that account existence should be verified separately when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->